### PR TITLE
fix: fixed broking dateTimeFormat when reading response from mvc

### DIFF
--- a/src/Tochka.JsonRpc.Server/Services/ResponseReader.cs
+++ b/src/Tochka.JsonRpc.Server/Services/ResponseReader.cs
@@ -43,7 +43,7 @@ namespace Tochka.JsonRpc.Server.Services
                          allowRawResponses,
                          nameof(actionResultType),
                          actionResultType);
-            
+
             var responseWrapper = await GetResponseWrapper(nestedHttpContext.Response, actionResultType, call, token);
 
             return responseWrapper switch
@@ -138,18 +138,17 @@ namespace Tochka.JsonRpc.Server.Services
             log.LogTrace("{action}: return raw response", nameof(GetResponseWrapper));
             return Task.FromResult<IServerResponseWrapper>(new RawServerResponseWrapper(response));
         }
-        
+
         protected internal virtual async Task<JToken> ReadJsonResponse(MemoryStream ms, Encoding encoding, CancellationToken token)
         {
-            using (var reader = new StreamReader(ms, encoding))
+            using var reader = new StreamReader(ms, encoding);
+            using var jsonReader = new JsonTextReader(reader)
             {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    // we obey how response was serialized
-                    log.LogTrace("Reading json from body");
-                    return await JToken.ReadFromAsync(jsonReader, token);
-                }
-            }
+                DateParseHandling = DateParseHandling.None
+            };
+            // we obey how response was serialized
+            log.LogTrace("Reading json from body");
+            return await JToken.ReadFromAsync(jsonReader, token);
         }
 
         protected internal virtual string ReadTextBody(MemoryStream ms, Encoding encoding)

--- a/src/tests/Tochka.JsonRpc.Server.Tests/Services/ResponseReaderTests.cs
+++ b/src/tests/Tochka.JsonRpc.Server.Tests/Services/ResponseReaderTests.cs
@@ -131,6 +131,21 @@ namespace Tochka.JsonRpc.Server.Tests.Services
         }
 
         [Test]
+        public async Task Test_ReadJsonResponse_ReadsJsonAndDoNotConvertDateTimeFormat()
+        {
+            var encoding = Encoding.UTF8;
+            var value = @"{
+  ""created_at"": ""2022-05-05T05:05:05.123000Z""
+}";
+            var ms = new MemoryStream(encoding.GetBytes(value));
+
+            var result = await responseReaderMock.Object.ReadJsonResponse(ms, encoding, new CancellationToken());
+
+            result.ToString().Should().Be(value);
+            responseReaderMock.Verify(x => x.ReadJsonResponse(It.IsAny<MemoryStream>(), It.IsAny<Encoding>(), It.IsAny<CancellationToken>()));
+        }
+
+        [Test]
         public async Task Test_HandleUnknownResult_ReturnsRaw()
         {
             var responseMock = new Mock<HttpResponse>();
@@ -160,7 +175,7 @@ namespace Tochka.JsonRpc.Server.Tests.Services
             var jsonResult = result as JsonServerResponseWrapper;
             Assert.AreEqual(json, jsonResult.Value);
             Assert.AreEqual(headers, jsonResult.Headers);
-            
+
             responseReaderMock.Verify(x => x.FormatHttpErrorResponse(It.IsAny<HttpResponse>(), It.IsAny<string>()));
             responseReaderMock.Verify(x => x.ReadTextBody(It.IsAny<MemoryStream>(), It.IsAny<Encoding>()));
             responseReaderMock.Verify(x => x.HandleNullResult(It.IsAny<HttpResponse>(), It.IsAny<IUntypedCall>(), It.IsAny<MemoryStream>(), It.IsAny<Encoding>(), It.IsAny<CancellationToken>()));
@@ -323,7 +338,7 @@ namespace Tochka.JsonRpc.Server.Tests.Services
             Func<Task> action = async () => await responseReaderMock.Object.GetResponse(httpContextMock.Object, Mock.Of<IUntypedCall>(), false, new CancellationToken());
 
             await action.Should().ThrowAsync<JsonRpcInternalException>();
-            
+
             responseReaderMock.Verify(x => x.GetResponseWrapper(It.IsAny<HttpResponse>(), It.IsAny<Type>(), It.IsAny<IUntypedCall>(), It.IsAny<CancellationToken>()));
             responseReaderMock.Verify(x => x.GetResponse(It.IsAny<HttpContext>(), It.IsAny<IUntypedCall>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
         }


### PR DESCRIPTION
При считывании ответа от MVC фреймворка в JToken, ломается форматирование DateTime'ов, хотя есть комментарий

> we obey how response was serialized

Исправил поведение изменения формата DateTime'ов, при считывании ответа.