### PR TITLE
fix: allow PropertyNamingPolicy = null

### DIFF
--- a/src/Tochka.JsonRpc.Server/Binding/JsonRpcParameterModelConvention.cs
+++ b/src/Tochka.JsonRpc.Server/Binding/JsonRpcParameterModelConvention.cs
@@ -44,7 +44,7 @@ internal class JsonRpcParameterModelConvention : IParameterModelConvention
         foreach (var actionSelector in parameter.Action.Selectors)
         {
             var jsonSerializerOptions = ServerUtils.GetDataJsonSerializerOptions(actionSelector.EndpointMetadata, options, serializerOptionsProviders);
-            var propertyName = jsonSerializerOptions.PropertyNamingPolicy!.ConvertName(parameter.ParameterName);
+            var propertyName = jsonSerializerOptions.ConvertName(parameter.ParameterName);
             var parametersMetadata = actionSelector.EndpointMetadata.Get<JsonRpcActionParametersMetadata>();
             if (parametersMetadata == null)
             {

--- a/src/Tochka.JsonRpc.Server/Routing/JsonRpcActionModelConvention.cs
+++ b/src/Tochka.JsonRpc.Server/Routing/JsonRpcActionModelConvention.cs
@@ -75,8 +75,8 @@ internal class JsonRpcActionModelConvention : IActionModelConvention
         var methodStyleAttribute = selector.EndpointMetadata.Get<JsonRpcMethodStyleAttribute>();
         var methodStyle = methodStyleAttribute?.MethodStyle ?? options.DefaultMethodStyle;
 
-        var controllerName = jsonSerializerOptions.PropertyNamingPolicy!.ConvertName(action.Controller.ControllerName);
-        var actionName = jsonSerializerOptions.PropertyNamingPolicy.ConvertName(action.ActionName);
+        var controllerName = jsonSerializerOptions.ConvertName(action.Controller.ControllerName);
+        var actionName = jsonSerializerOptions.ConvertName(action.ActionName);
         return methodStyle switch
         {
             JsonRpcMethodStyle.ControllerAndAction => $"{controllerName}{JsonRpcConstants.ControllerMethodSeparator}{actionName}",

--- a/src/tests/Tochka.JsonRpc.OpenRpc.Tests/Services/OpenRpcDocumentGeneratorTests.cs
+++ b/src/tests/Tochka.JsonRpc.OpenRpc.Tests/Services/OpenRpcDocumentGeneratorTests.cs
@@ -1028,7 +1028,7 @@ public class OpenRpcDocumentGeneratorTests
     {
     }
 
-    private class ValidJsonRpcController : JsonRpcControllerBase
+    private sealed class ValidJsonRpcController : JsonRpcControllerBase
     {
         public void ValidJsonRpcMethod()
         {


### PR DESCRIPTION
To fix allow PropertyNamingPolicy = null use ConvertName() from Tochka.JsonRpc.Common.Extensions

Add sealed, because was error: "  OpenRpcDocumentGeneratorTests.cs(1031, 19): [CA1852] Тип \"ValidJsonRpcController\" может быть запечатанным, так как у него нет подтипов в содержащей его сборке и он невидим извне (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852) "